### PR TITLE
Default "this" improved for ".when"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This example code computes `lastName` from `firstName` and `lastName`:
 var person = Model();
 
 person.when(["firstName", "lastName"], function (firstName, lastName) {
-  person.fullName = firstName + " " + lastName;
+  this.fullName = firstName + " " + lastName;
 });
 
 person.when("fullName", function (fullName) {

--- a/src/model.js
+++ b/src/model.js
@@ -241,6 +241,10 @@ define([], function () {
     // to be called appropriately.
     function when(properties, callback, thisArg) {
 
+      // Make sure the default "this." becomes 
+      // the object you called ".when" on
+      thisArg = thisArg || this
+
       // Support passing either single string or 
       // an array of strings as the `properties` argument.
       if(!(properties instanceof Array)) {

--- a/src/model.js
+++ b/src/model.js
@@ -243,7 +243,7 @@ define([], function () {
 
       // Make sure the default "this." becomes 
       // the object you called ".when" on
-      thisArg = thisArg || this
+      thisArg = thisArg || this;
 
       // Support passing either single string or 
       // an array of strings as the `properties` argument.


### PR DESCRIPTION
Make sure the default "this." becomes the object you called ".when" on - and not the window object

Now you can write:

``` javascript
person.when(["firstName", "lastName"], function (firstName, lastName) {
  this.fullName = firstName + " " + lastName;
});
```

instead of 

```
person.when(["firstName", "lastName"], function (firstName, lastName) {
  person.fullName = firstName + " " + lastName;
});
```

Leaving your code more generic.
