### PR TITLE
Only package dist folder for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "type": "git",
     "url": "https://github.com/curran/model.git"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "test": "gulp test"
   },


### PR DESCRIPTION
Currently when someone installs model-js as a dependency the entire working directory is downloaded to their filesystem.  Including `docs`, `examples`, `images`, and `lib` (which includes bootstrap, d3, etc).  With this change only `package.json`, `LICENSE`, `README.md` and the `dist` files will be downloaded.  See here:  https://docs.npmjs.com/files/package.json#files.  You can test what files get packaged by executing `npm pack`.
