### PR TITLE
Bower doesn't use version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "model",
-  "version": "0.2.3",
   "homepage": "https://github.com/curran/model",
   "authors": [
     "Curran <curran.kelleher@gmail.com>",


### PR DESCRIPTION
Bower uses git tags as a version number.  Version numbers in bower.json are deprecated.  https://github.com/bower/spec/blob/master/json.md#version
